### PR TITLE
Use a list of pre-allocated buffers for sprite rendering.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ pub struct Graphics {
     pub vsync: bool,
     pub fullscreen: bool,
     pub max_fps: u32,
+    pub fxaa: bool,
 }
 
 impl Default for Graphics {
@@ -21,6 +22,7 @@ impl Default for Graphics {
             vsync: false,
             fullscreen: false,
             max_fps: 120,
+            fxaa: false,
         }
     }
 }

--- a/src/graphics/systems/draw_sprites.rs
+++ b/src/graphics/systems/draw_sprites.rs
@@ -49,6 +49,10 @@ fn process(sys: &mut DrawSprites, data: &mut DataHelper) {
 
     let mut frame = data.services.graphics.current_frame.take().unwrap();
     for (&tex, instances) in instances.iter_mut() {
+        if instances.is_empty() {
+            continue;
+        }
+        
         data.services
             .graphics
             .draw_sprites(&mut frame, instances, tex);

--- a/src/graphics/systems/end_frame.rs
+++ b/src/graphics/systems/end_frame.rs
@@ -8,15 +8,21 @@ use DataHelper;
 pub struct EndFrame;
 
 fn process(_: &mut EndFrame, data: &mut DataHelper) {
-    data.services
-        .graphics
-        .current_frame
-        .take()
-        .map(|f| f.finish().unwrap());
-    
-    println!("draw count: {}", data.services.graphics.draw_count);
-    
+    data.services.graphics.current_frame.take().map(|mut f| {
+        if CONFIG.graphics.fxaa {
+            data.services.graphics.fxaa(&mut f);
+        }
+        f.finish().unwrap()
+    });
+
+    println!(
+        "draw count: {} ({} tile chunk layers)",
+        data.services.graphics.draw_count,
+        data.services.graphics.tile_draw_count
+    );
+
     data.services.graphics.draw_count = 0;
+    data.services.graphics.tile_draw_count = 0;
 
     let min_frametime = 1_000_000_000 / CONFIG.graphics.max_fps as u64;
     while data.services.timer.immediate_frametime_ns() < min_frametime {

--- a/src/physics/ext.rs
+++ b/src/physics/ext.rs
@@ -1,0 +1,18 @@
+use wrapped2d::b2;
+use physics as p;
+
+pub trait BodyExt {
+    fn apply_horiz_accel(&mut self, force: f32);
+    fn apply_vert_impulse(&mut self, impulse: f32);
+}
+
+impl BodyExt for b2::MetaBody<p::EntityUserData> {
+    fn apply_horiz_accel(&mut self, force: f32) {
+        self.apply_force_to_center(&b2::Vec2 { x: force, y: 0.0 }, true);
+    }
+
+    fn apply_vert_impulse(&mut self, impulse: f32) {
+        let world_center = *self.world_center();
+        self.apply_linear_impulse(&b2::Vec2 { x: 0.0, y: impulse }, &world_center, true);
+    }
+}

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -6,11 +6,12 @@ pub use self::body::Body;
 pub use self::run::PhysicsRun;
 pub use self::update::PhysicsUpdate;
 
+pub mod ext;
 pub mod body;
 pub mod run;
 pub mod update;
 
-pub const GRAVITY:b2::Vec2 = b2::Vec2{ x: 0.0, y: -15.0 };
+pub const GRAVITY: b2::Vec2 = b2::Vec2 { x: 0.0, y: -15.0 };
 
 pub struct World {
     pub world: b2::World<EntityUserData>,
@@ -18,9 +19,7 @@ pub struct World {
 
 impl World {
     pub fn new() -> Self {
-
-        let world = b2::World::<EntityUserData>::new(&GRAVITY);
-
+        let world = b2::World::new(&GRAVITY);
         World { world }
     }
 }

--- a/src/player/update.rs
+++ b/src/player/update.rs
@@ -1,10 +1,8 @@
-use wrapped2d::b2;
-
-extern crate winit;
+use winit;
 
 use {DataHelper, EntityIter};
-
-use physics;
+use physics as p;
+use physics::ext::BodyExt;
 
 #[derive(Default, System)]
 #[system_type(Entity)]
@@ -52,13 +50,7 @@ fn process(_: &mut PlayerUpdate, players: EntityIter, data: &mut DataHelper) {
                 new_force = -(TARGET_VELOCITY + body_velocity.x) * body_mass / dt;
             }
 
-            body.apply_force_to_center(
-                &b2::Vec2 {
-                    x: new_force,
-                    y: 0.0,
-                },
-                true,
-            );
+            body.apply_horiz_accel(new_force);
         }
 
         if right {
@@ -68,26 +60,12 @@ fn process(_: &mut PlayerUpdate, players: EntityIter, data: &mut DataHelper) {
                 new_force = (TARGET_VELOCITY - body_velocity.x) * body_mass / dt;
             }
 
-            body.apply_force_to_center(
-                &b2::Vec2 {
-                    x: new_force,
-                    y: 0.0,
-                },
-                true,
-            );
+            body.apply_horiz_accel(new_force);
         }
 
         if jump && jump_detector.grounded {
-            let world_center = *body.world_center();
-            let impulse = (-2.0 * physics::GRAVITY.y * JUMP_HEIGHT).sqrt() * body_mass;
-            body.apply_linear_impulse(
-                &b2::Vec2 {
-                    x: 0.0,
-                    y: impulse,
-                },
-                &world_center,
-                true,
-            )
+            let impulse = (-2.0 * p::GRAVITY.y * JUMP_HEIGHT).sqrt() * body_mass;
+            body.apply_vert_impulse(impulse);
         }
 
         if !left && !right {
@@ -98,13 +76,7 @@ fn process(_: &mut PlayerUpdate, players: EntityIter, data: &mut DataHelper) {
                 new_force = -body_velocity.x * body_mass / dt;
             }
 
-            body.apply_force_to_center(
-                &b2::Vec2 {
-                    x: new_force,
-                    y: 0.0,
-                },
-                true,
-            );
+            body.apply_horiz_accel(new_force);
         }
     }
 }


### PR DESCRIPTION
Most sprites should be using <=32 sprites per texture id, so use buffers
that big. Also added tracking for how many of the draw calls each frame are
from a {layer,chunk,tileset} chunk draw